### PR TITLE
restrict PATCH endpoint only to site managers

### DIFF
--- a/src/clms/downloadtool/api/services/datarequest_status_patch/configure.zcml
+++ b/src/clms/downloadtool/api/services/datarequest_status_patch/configure.zcml
@@ -7,7 +7,7 @@
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".patch.datarequest_status_patch"
     name="@datarequest_status_patch"
-    permission="clms.downloadtool.usedownloadtool"
+    permission="cmf.ManagePortal"
     />
 
 </configure>


### PR DESCRIPTION
Only site managers should be able to do PATCH requests to the download tool. 
A user with manager permission should be used by FME to signal the finalization and errors of the download tool, not a standard logged-in user